### PR TITLE
pass position in info panel

### DIFF
--- a/R/busy.R
+++ b/R/busy.R
@@ -103,7 +103,7 @@ busy <- function(loader = "dots", position = "top right") {
     tags$script(
       'function checkifrunning() {
         var is_running = $("html").attr("class").includes("shiny-busy");
-        if (is_running){
+        if (is_running){ #nolint
          $("#loading").show()
         } else {
          $("#loading").hide()

--- a/R/busy.R
+++ b/R/busy.R
@@ -103,7 +103,7 @@ busy <- function(loader = "dots", position = "top right") {
     tags$script(
       'function checkifrunning() {
         var is_running = $("html").attr("class").includes("shiny-busy");
-        if (is_running){ #nolint
+        if (is_running) {
          $("#loading").show()
         } else {
          $("#loading").hide()

--- a/R/display.R
+++ b/R/display.R
@@ -17,7 +17,6 @@ display <- function(message, position = "top right", type = "message") {
   plausible_info_panel_call <- tryCatch(sys.call(-8), error = function(e) "")
   is_called_in_info_panel <- isTRUE(any(grepl("infoPanel|info_panel", plausible_info_panel_call)))
   if (is_called_in_info_panel) {
-    position <- get_args("info_panel")$position
     fixed_layout <- ""
   }
   splitted_position <- unlist(strsplit(position, " "))

--- a/R/panel.R
+++ b/R/panel.R
@@ -17,6 +17,6 @@ info_panel <- function(..., position = "top right") {
 #'
 #' @return div which wraps your all info boxes to display it in the position corner of your shiny app.
 #' @export
-infoPanel <- function(..., position = "top right") {
+infoPanel <- function(..., position = "top right") { #nolint
  info_panel(..., position = position)
 }

--- a/R/panel.R
+++ b/R/panel.R
@@ -6,7 +6,8 @@
 #' @return div which wraps your all info boxes to display it in the position corner of your shiny app.
 #' @export
 info_panel <- function(..., position = "top right") {
-  display(tagList(...), position = position, type = "info_panel")
+  elements <- lapply(list(...), display, position = position)
+  display(tagList(list = elements), position = position, type = "info_panel")
 }
 
 #' Wrapper for info_panel function


### PR DESCRIPTION
Closes #16 

Changed way of passing position argument in `info_panel` to avoid checking arguments of the parent function.